### PR TITLE
Returns $this from setDeliverySameAsBilling() so method chaining can be used.

### DIFF
--- a/lib/SagePay.php
+++ b/lib/SagePay.php
@@ -529,6 +529,8 @@ class SagePay {
 		$this->setDeliveryCountry($this->getBillingCountry());
 		$this->setDeliveryState($this->getBillingState());
 		$this->setDeliveryPhone($this->getBillingPhone());
+
+		return $this;
 	}
 
 


### PR DESCRIPTION
Previously we needed to do this...

    function someMethod($data) {
        $this->sagePay
            ->setCurrency($this->config['currency'])
            ->setAmount($data['amount'])
            ->setDescription($data['description'])
            ->setBillingSurname($data['surname'])
            ->setBillingFirstnames($data['first_name'])
            ->setBillingCity($data['city'])
            ->setBillingPostCode($data['postcode'])
            ->setBillingAddress1($data['address'])
            ->setBillingCountry($this->config['billing_country'])
            ->setSuccessURL($this->config['success_url'])
            ->setFailureURL($this->config['failure_url']);

        $this->sagePay->setDeliverySameAsBilling();

        return $this->sagePay->getCrypt(); 
    }

With this pull request, now we can chain em all like so...

    function someMethod($data) {
        return $this->sagePay
            ->setCurrency($this->config['currency'])
            ->setAmount($data['amount'])
            ->setDescription($data['description'])
            ->setBillingSurname($data['surname'])
            ->setBillingFirstnames($data['first_name'])
            ->setBillingCity($data['city'])
            ->setBillingPostCode($data['postcode'])
            ->setBillingAddress1($data['address'])
            ->setBillingCountry($this->config['billing_country'])
            ->setSuccessURL($this->config['success_url'])
            ->setFailureURL($this->config['failure_url'])
            ->setDeliverySameAsBilling()
            ->getCrypt(); 
    }