### PR TITLE
Mcrypt has been abandoned in the latest versions of PHP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "tolzhabayev/sagepayform-php",
+    "description": "A simple PHP class to integrate sagepayForm v3.00 into your website.",
+    "type": "library",
+    "license": "MIT",
+    "autoload": {
+        "files": ["lib/SagePay.php"]
+    }
+}

--- a/lib/SagePay.php
+++ b/lib/SagePay.php
@@ -542,13 +542,13 @@ class SagePay {
 
 	protected function encryptAndEncode($strIn) {
 		$strIn = $this->pkcs5_pad($strIn, 16);
-		return "@".bin2hex(mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $this->encryptPassword, $strIn, MCRYPT_MODE_CBC, $this->encryptPassword));
+		return "@".bin2hex(openssl_encrypt($string, 'AES-128-CBC', $this->encryptPassword, OPENSSL_RAW_DATA, $this->encryptPassword));
 	}
 
 	protected function decodeAndDecrypt($strIn) {
 		$strIn = substr($strIn, 1);
 		$strIn = pack('H*', $strIn);
-		return mcrypt_decrypt(MCRYPT_RIJNDAEL_128, $this->encryptPassword, $strIn, MCRYPT_MODE_CBC, $this->encryptPassword);
+		return openssl_decrypt($strIn, 'AES-128-CBC', $this->encryptPassword, OPENSSL_RAW_DATA, $this->encryptPassword);
 	}
 
 


### PR DESCRIPTION
Mcrypt extension will no longer be avaiable in the new PHP7.x in favor of OpenSLL which should work for in both PHP5 and 7 versions