### PR TITLE
Changed deprecated mcrypt for open ssl, covers issue #24

### DIFF
--- a/lib/SagePay.php
+++ b/lib/SagePay.php
@@ -541,7 +541,7 @@ class SagePay {
 		return $sagePayResponse;
 	}
 	
-	protected function encryptAndEncode($strIn): string
+	protected function encryptAndEncode($strIn)
 	{
 		$strIn = $this->pkcs5_pad($strIn, 16);
 		$encrypted = openssl_encrypt($strIn, $this->encryptMethod, $this->encryptPassword, OPENSSL_RAW_DATA, $this->encryptPassword);
@@ -550,7 +550,7 @@ class SagePay {
 
 	}
 	
-	protected function decodeAndDecrypt(string $strIn):string
+	protected function decodeAndDecrypt($strIn)
 	{
 		$strIn = substr($strIn, 1);
 		$strIn = pack('H*', $strIn);

--- a/lib/SagePay.php
+++ b/lib/SagePay.php
@@ -52,7 +52,8 @@ class SagePay {
 	protected $language;
 	protected $website;
 	protected $encryptPassword = "PUTYOURPASSWORDHERE";
-
+	protected $encryptMethod = "AES-128-CBC";
+	
 	public function __construct() {
 		$this->setVendorTxCode($this->createVendorTxCode());
 	}
@@ -539,16 +540,23 @@ class SagePay {
 		parse_str($decodedString, $sagePayResponse);
 		return $sagePayResponse;
 	}
-
-	protected function encryptAndEncode($strIn) {
+	
+	protected function encryptAndEncode($strIn): string
+	{
 		$strIn = $this->pkcs5_pad($strIn, 16);
-		return "@".bin2hex(mcrypt_encrypt(MCRYPT_RIJNDAEL_128, $this->encryptPassword, $strIn, MCRYPT_MODE_CBC, $this->encryptPassword));
-	}
+		$encrypted = openssl_encrypt($strIn, $this->encryptMethod, $this->encryptPassword, OPENSSL_RAW_DATA, $this->encryptPassword);
+		$encrypted = "@".bin2hex($encrypted);
+		return $encrypted;
 
-	protected function decodeAndDecrypt($strIn) {
+	}
+	
+	protected function decodeAndDecrypt(string $strIn):string
+	{
 		$strIn = substr($strIn, 1);
 		$strIn = pack('H*', $strIn);
-		return mcrypt_decrypt(MCRYPT_RIJNDAEL_128, $this->encryptPassword, $strIn, MCRYPT_MODE_CBC, $this->encryptPassword);
+		$decrypted = openssl_decrypt($strIn, $this->encryptMethod, $this->encryptPassword, OPENSSL_RAW_DATA, $this->encryptPassword);
+		return $decrypted;
+
 	}
 
 


### PR DESCRIPTION
Fixes mcrypt deprecation in php >= 7.1 . Using openssl instead.